### PR TITLE
Adding excludes to the divshot configuration.

### DIFF
--- a/divshot.json
+++ b/divshot.json
@@ -1,4 +1,10 @@
 {
   "name": "daytonreap",
-  "routes": { "**": "app/index.html" }
+  "routes": { "**": "app/index.html" },
+  "exclude": [".htaccess",
+              ".sass-cache",
+              ".tmp",
+              ".DS_Store",
+              "node_modules",
+              "static/data/reaps.json.*"]
 }


### PR DESCRIPTION
"Hashing the deploy directory" can hang (or else take longer than I was willing to wait (20+ minutes) if it tries to hash everything. This tells it to ignore several of the unnecessary directories. This isn't a comprehensive list of things to ignore, but it gets the most important ones.

This is only for deploying to divshot - which is not our production environment, only a place for testing changes.